### PR TITLE
Updating php requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 		"source": "https://github.com/CakeDC/migrations"
 	},
 	"require": {
-		"php": ">=5.3.0",
+		"php": ">=7.2.0",
+		"cakephp/cakephp": ">=2.9.0",
 		"composer/installers": "*"
 	}
 }


### PR DESCRIPTION
Projects relying on older versions of php and
cakephp aren't compatible with recent changes.
Updating the composer file to stop issues
occurring.