### PR TITLE
Reducing php requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"source": "https://github.com/CakeDC/migrations"
 	},
 	"require": {
-		"php": ">=7.2.0",
+		"php": ">=5.3.0",
 		"cakephp/cakephp": ">=2.9.0",
 		"composer/installers": "*"
 	}


### PR DESCRIPTION
The update to switch Object with CakeObject only
relies on the version of cake, not php so reducing
the required version of php to it's original
requirement.